### PR TITLE
Avoiding refuse connections in Heroku

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -13,7 +13,7 @@ class App extends Component {
 
   componentDidMount() {
     let me = this;
-    fetch("http://localhost:3001/api/petrogustavo")
+    fetch("api/petrogustavo")
       .then((res) => {
         return res.json();
       })


### PR DESCRIPTION
This change in the parameter of the fetch function allows it to make the request to the backend, without any refuse connection when deploying in Heroku.